### PR TITLE
Fixed Shulker Problem

### DIFF
--- a/src/main/java/com/shweit/itemlocator/ItemLocator.java
+++ b/src/main/java/com/shweit/itemlocator/ItemLocator.java
@@ -2,6 +2,7 @@ package com.shweit.itemlocator;
 
 import com.shweit.itemlocator.commands.RegisterCommands;
 import com.shweit.itemlocator.listeners.InventoryClose;
+import com.shweit.itemlocator.listeners.ShulkerBreakListener;
 import com.shweit.itemlocator.utils.DatabaseConnectionManager;
 import com.shweit.itemlocator.utils.Translator;
 import com.shweit.itemlocator.utils.UpdateChecker;
@@ -47,5 +48,6 @@ public final class ItemLocator extends JavaPlugin {
     private void registerListeners() {
         getServer().getPluginManager().registerEvents(new UpdateChecker(), this);
         getServer().getPluginManager().registerEvents(new InventoryClose(), this);
+        getServer().getPluginManager().registerEvents(new ShulkerBreakListener(), this);
     }
 }

--- a/src/main/java/com/shweit/itemlocator/listeners/ShulkerBreakListener.java
+++ b/src/main/java/com/shweit/itemlocator/listeners/ShulkerBreakListener.java
@@ -1,0 +1,56 @@
+package com.shweit.itemlocator.listeners;
+
+import com.shweit.itemlocator.utils.DatabaseConnectionManager;
+import com.shweit.itemlocator.utils.Logger;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public final class ShulkerBreakListener implements Listener {
+
+    @EventHandler
+    public void onBlockBreak(final BlockBreakEvent event) {
+        Block block = event.getBlock();
+
+        // Check if the block is a Shulker box
+        if (isShulkerBox(block.getType())) {
+            String playerUUID = event.getPlayer().getUniqueId().toString();
+            String coordinates = block.getLocation().getBlockX() + ","
+                    + block.getLocation().getBlockY() + ","
+                    + block.getLocation().getBlockZ();
+
+            // Remove the Shulker box data from the database
+            deleteShulkerBoxData(playerUUID, coordinates);
+        }
+    }
+
+    private boolean isShulkerBox(final Material material) {
+        return switch (material) {
+            case SHULKER_BOX, WHITE_SHULKER_BOX, ORANGE_SHULKER_BOX, MAGENTA_SHULKER_BOX, LIGHT_BLUE_SHULKER_BOX,
+                 YELLOW_SHULKER_BOX, LIME_SHULKER_BOX, PINK_SHULKER_BOX, GRAY_SHULKER_BOX, LIGHT_GRAY_SHULKER_BOX,
+                 CYAN_SHULKER_BOX, PURPLE_SHULKER_BOX, BLUE_SHULKER_BOX, BROWN_SHULKER_BOX, GREEN_SHULKER_BOX,
+                 RED_SHULKER_BOX, BLACK_SHULKER_BOX -> true;
+            default -> false;
+        };
+    }
+
+    private void deleteShulkerBoxData(final String playerUUID, final String coordinates) {
+        String query = "DELETE FROM items WHERE UUID = ? AND coordinates = ? AND container = 'SHULKER_BOX'";
+
+        try (Connection connection = new DatabaseConnectionManager().getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID);
+            statement.setString(2, coordinates);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            Logger.error("Failed to delete Shulker box data from the database");
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Before this PR the data in the database was not deleted when the Shulker Box was destroyed, meaning we have double entries in the database and invalid data. Here what it looked like:
<img width="734" alt="image" src="https://github.com/user-attachments/assets/014b2fad-a90a-4c51-8a99-10d2014850ed">

Now when the Shulker gets destroyed, the data in the database will get deleted